### PR TITLE
Revisions - SDG01

### DIFF
--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -261,7 +261,7 @@ TS=
           ("microfinanc*" OR "micro-financ*" OR "microinsurance" OR "micro-insurance" OR "microcredit" OR "micro-credit" OR "microloan$" OR "micro-loan$"
           OR "banks" OR "a bank" OR "banking" OR "bank account$"
           OR "digital finance" OR "mobile money" OR "electronic payments" OR "digital payment$" OR "fintech"
-          OR "credit" OR "savings" OR "insurance" OR "payment service$" OR "transfer service$" OR "transfer funds"
+          OR "credit" OR "entrepreneurial finance" OR "loan$" OR "savings" OR "insurance" OR "payment service$" OR "transfer service$" OR "transfer funds"
           OR (("financial" OR "monetary") NEAR/1 ("resourc*" OR "opportunit*" OR "asset*" OR "servic*"))
           OR "financial inclusion"
           )

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -271,14 +271,14 @@ TS=
       OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
       OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
       OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
-      OR (("person$" OR "people$" OR "adult$") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
+      OR (("person$" OR "people$" OR "adult$" OR "men") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
       OR "disabled" OR "disabilities" OR "disability"
       OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
       OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
       OR "women" OR "woman" OR "girls" OR "girl"
       OR "pregnant" OR "pregnancy" OR "maternity"
       OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
-      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*"
+      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*" OR "non-binary" OR "nonbinary" OR "gender non-conforming" OR "gender nonconforming" OR "queer"
       OR "living with HIV" OR "living with AIDS"
       OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
       OR "indigenous group$"
@@ -335,14 +335,14 @@ TS=
       OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
       OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
       OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
-      OR (("person$" OR "people$" OR "adult$") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
+      OR (("person$" OR "people$" OR "adult$" OR "men") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
       OR "disabled" OR "disabilities" OR "disability"
       OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
       OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
       OR "women" OR "woman" OR "girls" OR "girl"
       OR "pregnant" OR "pregnancy" OR "maternity"
       OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
-      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*"
+      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*" OR "non-binary" OR "nonbinary" OR "gender non-conforming" OR "gender nonconforming" OR "queer"
       OR "living with HIV" OR "living with AIDS"
       OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
       OR "indigenous group$"
@@ -399,23 +399,23 @@ TS=
         )
   )
   AND
-    ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"
-    OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
-    OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
-    OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
-    OR (("person$" OR "people$" OR "adult$") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
-    OR "disabled" OR "disabilities" OR "disability"
-    OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
-    OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
-    OR "women" OR "woman" OR "girls" OR "girl"
-    OR "pregnant" OR "pregnancy" OR "maternity"
-    OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
-    OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*"
-    OR "living with HIV" OR "living with AIDS"
-    OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
-    OR "indigenous group$"
-    OR "least developed countr*" OR "least developed nation$" OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
-    )
+      ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"
+      OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
+      OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
+      OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
+      OR (("person$" OR "people$" OR "adult$" OR "men") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
+      OR "disabled" OR "disabilities" OR "disability"
+      OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
+      OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
+      OR "women" OR "woman" OR "girls" OR "girl"
+      OR "pregnant" OR "pregnancy" OR "maternity"
+      OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
+      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*" OR "non-binary" OR "nonbinary" OR "gender non-conforming" OR "gender nonconforming" OR "queer"
+      OR "living with HIV" OR "living with AIDS"
+      OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
+      OR "indigenous group$"
+      OR "least developed countr*" OR "least developed nation$" OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
+      )
 )
 ```
 

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -299,7 +299,7 @@ TS=
         )
         NEAR/5
             ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
-            OR "ownership" OR "right$"
+            OR "ownership" OR "landownership" OR "homeownership" OR "right$"
             OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control" OR "economic control"
             OR "affordab*" OR "pro poor"
             OR "empower*" OR "inclusion" OR "sharing"

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -291,7 +291,7 @@ TS=
 
 This phrase covers ensuring access and rights to economic resources, natural resources, land, property and inheritance. The basic structure is *action + access/rights + resources + poor/vulnerable*.
 
-"security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example).
+"security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example). `("of" NEAR/1 "assets")` is used to help filter out many works from business (e.g. return on assets).
 
 ```py
 TS=
@@ -308,7 +308,7 @@ TS=
         NEAR/5
             ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
             OR "ownership" OR "right$"
-            OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control"
+            OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control" OR "economic control"
             OR "affordab*" OR "pro poor"
             OR "empower*" OR "inclusion" OR "sharing"
             OR "tenure security" OR "secure tenure" OR "land tenure" OR "income security" OR "secure livelihood$"
@@ -327,7 +327,7 @@ TS=
     )
     NEAR/5
         ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labour market$"
-        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit"
+        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
         OR "land" OR "lands" OR "farmland$" OR "property" OR "natural resource$" OR "tenure"
         )
   )

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -231,10 +231,10 @@ Sources of terms for *financial services* included <a id="DESA">[Department of E
 TS=
 (
   (
-    ("ensure" OR "establish*" OR "propose*" OR "implement*"
-    OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
+    ("ensur*" OR "establish*" OR "propos*" OR "implement*"
+    OR "improv*" OR "increas*" OR "better" OR "reform*"
     OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
-    OR "develop" OR "development" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*"
+    OR "develop" OR "development" OR "attain*" OR "achiev*" OR "improv*" OR "strengthen*"
     OR "reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
     OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
     OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
@@ -291,10 +291,10 @@ The string finds quite many results about access/barriers to medical care relate
 TS=
 (
   (
-    ("ensure" OR "establish*" OR "propose*" OR "implement*"
-    OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
+    ("ensur*" OR "establish*" OR "propos*" OR "implement*"
+    OR "improv*" OR "increas*" OR "better" OR "reform*"
     OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
-    OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*" OR "reform*"
+    OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*"
     OR "reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
     OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
     OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
@@ -351,10 +351,12 @@ TS=
 (
   (
     (
-      ("ensure" OR "establish*" OR "propose*" OR "implement*"
-      OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
+      ("ensur*" OR "establish*" OR "propos*" OR "implement*"
+      OR "improv*" OR "increas*" OR "better" OR "reform*"
       OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
-      OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*"
+      OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*"
+      OR "reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
+      OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
       OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
       )
       NEAR/5

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -302,15 +302,16 @@ TS=
         ("ensure" OR "establish*" OR "propose*" OR "implement*"
         OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
         OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
-        OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*"
+        OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*" OR "reform*"
         OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
         )
         NEAR/5
             ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
-            OR "ownership" OR "control" OR "right$"
+            OR "ownership" OR "right$"
+            OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control"
             OR "affordab*" OR "pro poor"
             OR "empower*" OR "inclusion" OR "sharing"
-            OR "tenure security" OR "secure tenure" OR "income security" OR "secure livelihood$"
+            OR "tenure security" OR "secure tenure" OR "land tenure" OR "income security" OR "secure livelihood$"
             )
       )
       OR
@@ -320,13 +321,13 @@ TS=
         )
         NEAR/5
             ("inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*"
-            OR "unaffordab*" OR "exclusion" OR "land grab*" OR "insecurity"
+            OR "unaffordab*" OR "exclusion" OR "land grab*" OR "appropriation of land" OR "insecurity"
             )      
       )
     )
     NEAR/5
         ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labour market$"
-        OR "income" OR "livelihood$" OR "wealth" OR "inheritance"
+        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit"
         OR "land" OR "lands" OR "farmland$" OR "property" OR "natural resource$" OR "tenure"
         )
   )

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -285,44 +285,38 @@ This phrase covers ensuring access and rights to economic resources, natural res
 
 "security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example). `("of" NEAR/1 "assets")` is used to help filter out many works from business (e.g. return on assets).
 
+The string finds quite many results about access/barriers to medical care related to income, and access to healthcare in low-/middle- income countries. These are potentially outside of scope - they are related to vulnerable groups and access, but more to healthcare rather than economic resources directly. However, they are difficult to exclude without losing relevant results due to the word `income`.
+
 ```py
 TS=
 (
   (
-    (
-      (
-        ("ensure" OR "establish*" OR "propose*" OR "implement*"
-        OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
-        OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
-        OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*" OR "reform*"
-        OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
-        )
-        NEAR/5
-            ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
-            OR "ownership" OR "landownership" OR "homeownership" OR "right$"
-            OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control" OR "economic control"
-            OR "affordab*" OR "pro poor"
-            OR "empower*" OR "inclusion" OR "sharing"
-            OR "tenure security" OR "secure tenure" OR "land tenure" OR "income security" OR "secure livelihood$"
-            )
-      )
-      OR
-      (
-        ("reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
-        OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
-        )
-        NEAR/5
-            ("inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*"
-            OR "unaffordab*" OR "exclusion" OR "land grab*" OR "appropriation of land" OR "insecurity"
-            )      
-      )
+    ("ensure" OR "establish*" OR "propose*" OR "implement*"
+    OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
+    OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
+    OR "develop" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*" OR "reform*"
+    OR "reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
+    OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
+    OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
     )
     NEAR/5
-        ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labo$r market" OR "labo$r force"
-        OR "income" OR "earnings" OR "wage" OR "wages" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
-        OR "land" OR "lands" OR "landowner*" OR "farmland$" OR "livestock owner*" OR "livestock asset$"
-        OR "property" OR "home owner*" OR "homeowner*" OR "tenure" 
-        OR "natural resource$"
+        (
+          ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
+          OR "ownership" OR "landownership" OR "homeownership" OR "right$"
+          OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control" OR "economic control"
+          OR "affordab*" OR "pro poor"
+          OR "empower*" OR "inclusion" OR "sharing"
+          OR "tenure security" OR "secure tenure" OR "land tenure" OR "income security" OR "secure livelihood$"
+          OR "inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*"
+          OR "unaffordab*" OR "exclusion" OR "land grab*" OR "appropriation of land" OR "insecurity"
+          )
+          NEAR/15
+              ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labo$r market" OR "labo$r force"
+              OR "income" OR "earnings" OR "wage" OR "wages" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
+              OR "land" OR "lands" OR "landowner*" OR "farmland$" OR "livestock owner*" OR "livestock asset$"
+              OR "property" OR "home owner*" OR "homeowner*" OR "tenure" 
+              OR "natural resource$"
+              )
         )
   )
   AND

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -615,7 +615,7 @@ TS=
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v2.0.0: Caroline S. Armitage (Aug-Oct 2023), minor review Lise Vik Haugen.
+* v2.0.0, 2.1.0: Caroline S. Armitage, minor review Lise Vik Haugen.
 
 Specialist input: Awaiting specialist input.
 

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -318,9 +318,11 @@ TS=
       )
     )
     NEAR/5
-        ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labour market$"
-        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
-        OR "land" OR "lands" OR "farmland$" OR "property" OR "natural resource$" OR "tenure"
+        ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labo$r market" OR "labo$r force"
+        OR "income" OR "earnings" OR "wage" OR "wages" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
+        OR "land" OR "lands" OR "landowner*" OR "farmland$" OR "livestock owner*" OR "livestock asset$"
+        OR "property" OR "home owner*" OR "homeowner*" OR "tenure" 
+        OR "natural resource$"
         )
   )
   AND

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -231,40 +231,32 @@ Sources of terms for *financial services* included <a id="DESA">[Department of E
 TS=
 (
   (
-    (
-      (
-        ("ensure" OR "establish*" OR "propose*" OR "implement*"
-        OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
-        OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
-        OR "develop" OR "development" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*"
-        OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
-        )
-        NEAR/5
-            ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
-            OR "ownership" OR "control" OR "right$" OR "empower*" OR "inclusion"
-            OR "affordab*" OR "pro poor" OR "inexpensive" OR "free of charge" OR "free service$"
-            )
-      )
-      OR
-      (
-        ("reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
-        OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
-        )
-        NEAR/5
-            ("inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*" OR "exclusion"
-            OR "unaffordab*" OR "expensive"
-            OR "unbanked"
-            )      
-      )
+    ("ensure" OR "establish*" OR "propose*" OR "implement*"
+    OR "improv*" OR "increase" OR "increasing" OR "increased" OR "better"
+    OR "adopt*" OR "introduc*" OR "build*" OR "plan" OR "planning" OR "plans"
+    OR "develop" OR "development" OR "attain*" OR  "achiev*" OR "improv*" OR "strengthen*" OR "increas*"
+    OR "reduce" OR "reducing" OR "decreas*" OR "avoid*" OR "prevent*" OR "combat*"
+    OR "overcome" OR "stop*" OR "end" OR "ends" OR "ended" OR "ending" OR "remov*" OR "eliminat*" OR "eradicat*" OR "dismantl*"
+    OR "program*" OR "strateg*" OR "policy" OR "policies" OR "framework$" OR "initiative$" OR "law$" OR "legislat*"
     )
-    NEAR/15
-          ("microfinanc*" OR "micro-financ*" OR "microinsurance" OR "micro-insurance" OR "microcredit" OR "micro-credit" OR "microloan$" OR "micro-loan$"
-          OR "banks" OR "a bank" OR "banking" OR "bank account$"
-          OR "digital finance" OR "mobile money" OR "electronic payments" OR "digital payment$" OR "fintech"
-          OR "credit" OR "entrepreneurial finance" OR "loan$" OR "savings" OR "insurance" OR "payment service$" OR "transfer service$" OR "transfer funds"
-          OR (("financial" OR "monetary") NEAR/1 ("resourc*" OR "opportunit*" OR "asset*" OR "servic*"))
-          OR "financial inclusion"
+    NEAR/5
+        (
+          ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
+          OR "ownership" OR "control" OR "right$" OR "empower*" OR "inclusion"
+          OR "affordab*" OR "pro poor" OR "inexpensive" OR "free of charge" OR "free service$"
+          OR "inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*" OR "exclusion"
+          OR "unaffordab*" OR "expensive"
+          OR "unbanked"
           )
+          NEAR/15
+              ("microfinanc*" OR "micro-financ*" OR "microinsurance" OR "micro-insurance" OR "microcredit" OR "micro-credit" OR "microloan$" OR "micro-loan$"
+              OR "banks" OR "a bank" OR "banking" OR "bank account$"
+              OR "digital finance" OR "mobile money" OR "electronic payments" OR "digital payment$" OR "fintech"
+              OR "credit" OR "entrepreneurial finance" OR "loan$" OR "savings" OR "insurance" OR "payment service$" OR "transfer service$" OR "transfer funds"
+              OR (("financial" OR "monetary") NEAR/1 ("resourc*" OR "opportunit*" OR "asset*" OR "servic*"))
+              OR "financial inclusion"
+              )
+        )
   )
   AND
       ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -291,7 +291,7 @@ TS=
 
 This phrase covers ensuring access and rights to economic resources, natural resources, land, property and inheritance. The basic structure is *action + access/rights + resources + poor/vulnerable*.
 
-"security" is used in phrases because otherwise there are many results about food security. 
+"security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example).
 
 ```py
 TS=

--- a/SDG01_query_action_WoS.md
+++ b/SDG01_query_action_WoS.md
@@ -285,7 +285,7 @@ This phrase covers ensuring access and rights to economic resources, natural res
 
 "security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example). `("of" NEAR/1 "assets")` is used to help filter out many works from business (e.g. return on assets).
 
-The string finds quite many results about access/barriers to medical care related to income, and access to healthcare in low-/middle- income countries. These are potentially outside of scope - they are related to vulnerable groups and access, but more to healthcare rather than economic resources directly. However, they are difficult to exclude without losing relevant results due to the word `income`.
+The string finds quite many results about access/barriers to medical care related to income, and access to healthcare in low-/middle- income countries. These are potentially outside of scope - they are related to vulnerable groups and access, but more to healthcare rather than economic resources directly. However, they are difficult to exclude without losing relevant results due to the word `income`. We also consider them relevant to the "basic services" (healthcare) part of this target.
 
 ```py
 TS=

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -184,23 +184,23 @@ OR TS=
       )
   )
   AND
-    ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"
-    OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
-    OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
-    OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
-    OR (("person$" OR "people$" OR "adult$") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
-    OR "disabled" OR "disabilities" OR "disability"
-    OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
-    OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
-    OR "women" OR "woman" OR "girls" OR "girl"
-    OR "pregnant" OR "pregnancy" OR "maternity"
-    OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
-    OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*"
-    OR "living with HIV" OR "living with AIDS"
-    OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
-    OR "indigenous group$"
-    OR "least developed countr*" OR "least developed nation$" OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
-    )
+      ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"
+      OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
+      OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
+      OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
+      OR (("person$" OR "people$" OR "adult$" OR "men") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
+      OR "disabled" OR "disabilities" OR "disability"
+      OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
+      OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
+      OR "women" OR "woman" OR "girls" OR "girl"
+      OR "pregnant" OR "pregnancy" OR "maternity"
+      OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
+      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*" OR "non-binary" OR "nonbinary" OR "gender non-conforming" OR "gender nonconforming" OR "queer"
+      OR "living with HIV" OR "living with AIDS"
+      OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
+      OR "indigenous group$"
+      OR "least developed countr*" OR "least developed nation$" OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
+      )
 )
 ```
 
@@ -233,14 +233,14 @@ TS=
       OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
       OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
       OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
-      OR (("person$" OR "people$" OR "adult$") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
+      OR (("person$" OR "people$" OR "adult$" OR "men") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
       OR "disabled" OR "disabilities" OR "disability"
       OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
       OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
       OR "women" OR "woman" OR "girls" OR "girl"
       OR "pregnant" OR "pregnancy" OR "maternity"
       OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
-      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*"
+      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*" OR "non-binary" OR "nonbinary" OR "gender non-conforming" OR "gender nonconforming" OR "queer"
       OR "living with HIV" OR "living with AIDS"
       OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
       OR "indigenous group$"
@@ -289,23 +289,23 @@ TS=
         )
   )
   AND
-    ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"
-    OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
-    OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
-    OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
-    OR (("person$" OR "people$" OR "adult$") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
-    OR "disabled" OR "disabilities" OR "disability"
-    OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
-    OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
-    OR "women" OR "woman" OR "girls" OR "girl"
-    OR "pregnant" OR "pregnancy" OR "maternity"
-    OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
-    OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*"
-    OR "living with HIV" OR "living with AIDS"
-    OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
-    OR "indigenous group$"
-    OR "least developed countr*" OR "least developed nation$" OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
-    )
+      ("poverty" OR "the poor" OR "the poorest" OR "rural poor" OR "urban poor" OR "working poor" OR "destitute" OR "living in poverty"
+      OR (("poor" OR "poorest" OR "low* income") NEAR/3 ("household$" OR "people" OR "children" OR "communit*" OR "neighbo$rhood*"))
+      OR "the vulnerable" OR "vulnerable group$" OR "vulnerable communit*" OR "marginali?ed group$" OR "marginali$ed communit*" OR "disadvantaged group$" OR "disadvantaged communit*"
+      OR "slum" OR "slums" OR "shanty town$" OR "informal settlement*" OR "homeless"
+      OR (("person$" OR "people$" OR "adult$" OR "men") NEAR/3 ("vulnerable" OR "marginali$ed" OR "disadvantaged" OR "discriminated" OR "displaced*" OR "patient$" OR "trans" OR "intersex" OR "older" OR "old" OR "elderly" OR "retired" OR "indigenous"))
+      OR "disabled" OR "disabilities" OR "disability"
+      OR "elderly" OR "elders" OR "pensioners" OR "vulnerable seniors"
+      OR "unemployed" OR (("work" OR "workplace" OR "worker$" OR "occupational") NEAR/3 ("injury" OR "injuries" OR "illness*" OR "accident$"))
+      OR "women" OR "woman" OR "girls" OR "girl"
+      OR "pregnant" OR "pregnancy" OR "maternity"
+      OR "child" OR "children" OR "infant$" OR "babies" OR "newborn$" OR "toddler$" OR "youth$"
+      OR "sexual minorit*" OR "LGBT*" OR "lesbian$" OR "gay" OR "bisexual" OR "transgender*" OR "non-binary" OR "nonbinary" OR "gender non-conforming" OR "gender nonconforming" OR "queer"
+      OR "living with HIV" OR "living with AIDS"
+      OR "ethnic minorit*" OR "minority group$" OR "refugee$" OR "migrant$" OR "immigrant$" OR "asylum*"
+      OR "indigenous group$"
+      OR "least developed countr*" OR "least developed nation$" OR "Angola*" OR "Benin" OR "beninese" OR "Burkina Faso" OR "Burkina fasso" OR "burkinese" OR "burkinabe" OR "Burundi*" OR "Central African Republic" OR "Chad" OR "Comoros" OR "comoro islands" OR "iles comores" OR "Congo" OR "congolese" OR "Djibouti*" OR "Eritrea*" OR "Ethiopia*" OR "Gambia*" OR "Guinea" OR "Guinea-Bissau" OR "guinean" OR "Lesotho" OR "lesothan*" OR "Liberia*" OR "Madagasca*" OR "Malawi*" OR "Mali" OR "malian" OR "Mauritania*" OR "Mozambique" OR "mozambican$" OR "Niger" OR "Rwanda*" OR "Sao Tome and Principe" OR "Senegal*" OR "Sierra Leone*" OR "Somalia*" OR "South Sudan" OR "Sudan" OR "sudanese" OR "Togo" OR "togolese" OR "tongan" OR "Uganda*" OR "Tanzania*" OR "Zambia*" OR "Cambodia*" OR "Kiribati*" OR "Lao People’s democratic republic" OR "Laos" OR "Myanmar" OR "myanma" OR "Solomon islands" OR "Timor Leste" OR "Tuvalu*" OR "Vanuatu*" OR "Afghanistan" OR "afghan$" OR "Bangladesh*" OR "Bhutan*" OR "Nepal*" OR "Yemen*" OR "Haiti*"
+      )
 )
 ```
 

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -179,7 +179,7 @@ OR TS=
     NEAR/15
       ("banks" OR "a bank" OR "banking" OR "bank account$"
       OR "digital finance" OR "mobile money" OR "electronic payments" OR "digital payment$" OR "fintech"
-      OR "credit" OR "savings" OR "insurance" OR "payment service$" OR "transfer service$" OR "transfer funds"
+      OR "credit" OR "entrepreneurial finance" OR "loan$" OR "savings" OR "insurance" OR "payment service$" OR "transfer service$" OR "transfer funds"
       OR (("financial" OR "monetary") NEAR/1 ("resourc*" OR "opportunit*" OR "asset*" OR "servic*"))
       )
   )

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -215,7 +215,7 @@ TS=
 (
   (
     ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
-    OR "ownership" OR "right$"
+    OR "ownership" OR "landownership" OR "homeownership" OR "right$"
     OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control" OR "economic control"
     OR "affordab*" OR "pro poor"
     OR "empower*" OR "inclusion" OR "sharing"

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -215,16 +215,17 @@ TS=
 (
   (
     ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
-    OR "ownership" OR "control" OR "right$"
+    OR "ownership" OR "right$"
+    OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control"
     OR "affordab*" OR "pro poor"
     OR "empower*" OR "inclusion" OR "sharing"
-    OR "tenure security" OR "secure tenure" OR "income security" OR "secure livelihood$"
+    OR "tenure security" OR "secure tenure" OR "land tenure" OR "income security" OR "secure livelihood$"
     OR "inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*"
-    OR "unaffordab*" OR "exclusion" OR "land grab*" OR "insecurity"
+    OR "unaffordab*" OR "exclusion" OR "land grab*" OR "appropriation of land" OR "insecurity"
     )      
     NEAR/5
         ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labour market$"
-        OR "income" OR "livelihood$" OR "wealth" OR "inheritance"
+        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit"
         OR "land" OR "lands" OR "farmland$" OR "property" OR "natural resource$" OR "tenure"
         )
   )

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -208,7 +208,7 @@ OR TS=
 
 This phrase covers access and rights to economic resources, natural resources, land, property and inheritance. The elements of the phrase are: *access/rights + resources + poor/vulnerable*.
 
-"security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example).
+"security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example). `("of" NEAR/1 "assets")` is used to help filter out many works from business (e.g. return on assets).
 
 ```py
 TS=
@@ -216,7 +216,7 @@ TS=
   (
     ("access*" OR "equitab*" OR "equity" OR "equality" OR "equal"
     OR "ownership" OR "right$"
-    OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control"
+    OR "control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control" OR "economic control"
     OR "affordab*" OR "pro poor"
     OR "empower*" OR "inclusion" OR "sharing"
     OR "tenure security" OR "secure tenure" OR "land tenure" OR "income security" OR "secure livelihood$"
@@ -225,7 +225,7 @@ TS=
     )      
     NEAR/5
         ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labour market$"
-        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit"
+        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
         OR "land" OR "lands" OR "farmland$" OR "property" OR "natural resource$" OR "tenure"
         )
   )

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -208,7 +208,7 @@ OR TS=
 
 This phrase covers access and rights to economic resources, natural resources, land, property and inheritance. The elements of the phrase are: *access/rights + resources + poor/vulnerable*.
 
-"security" is used in phrases because otherwise there are many results about food security.  
+"security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example).
 
 ```py
 TS=

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -210,6 +210,8 @@ This phrase covers access and rights to economic resources, natural resources, l
 
 "security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example). `("of" NEAR/1 "assets")` is used to help filter out many works from business (e.g. return on assets).
 
+The string finds quite many results about access/barriers to medical care related to income, and access to healthcare in low-/middle- income countries. These are potentially outside of scope - they are related to vulnerable groups and access, but more to healthcare rather than economic resources directly. However, they are difficult to exclude without losing relevant results due to the word `income`.
+
 ```py
 TS=
 (
@@ -223,7 +225,7 @@ TS=
     OR "inaccessib*" OR "barrier$" OR "obstacle$" OR "unequal" OR "inequalit*" OR "inequitab*"
     OR "unaffordab*" OR "exclusion" OR "land grab*" OR "appropriation of land" OR "insecurity"
     )      
-    NEAR/5
+    NEAR/15
         ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labo$r market" OR "labo$r force"
         OR "income" OR "earnings" OR "wage" OR "wages" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
         OR "land" OR "lands" OR "landowner*" OR "farmland$" OR "livestock owner*" OR "livestock asset$"

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -535,7 +535,7 @@ NOT
 
 * Testing v1.2.2: Project group; see documentation https://doi.org/10.5281/zenodo.8386611
 
-* v2.0.0: Caroline S. Armitage (Aug-Oct 2023), minor review Lise Vik Haugen.
+* v2.0.0, 2.1.0: Caroline S. Armitage, minor review Lise Vik Haugen.
 
 Specialist input: Awaiting specialist input.
 

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -210,7 +210,7 @@ This phrase covers access and rights to economic resources, natural resources, l
 
 "security" is used in phrases because otherwise there are many results about food security. "control" is also used in phrases as it was found to cause too much noise alone (works mentioning "control groups" or "asthma control" for example). `("of" NEAR/1 "assets")` is used to help filter out many works from business (e.g. return on assets).
 
-The string finds quite many results about access/barriers to medical care related to income, and access to healthcare in low-/middle- income countries. These are potentially outside of scope - they are related to vulnerable groups and access, but more to healthcare rather than economic resources directly. However, they are difficult to exclude without losing relevant results due to the word `income`.
+The string finds quite many results about access/barriers to medical care related to income, and access to healthcare in low-/middle- income countries. These are potentially outside of scope - they are related to vulnerable groups and access, but more to healthcare rather than economic resources directly. However, they are difficult to exclude without losing relevant results due to the word `income`. We also consider them relevant to the "basic services" (healthcare) part of this target.
 
 ```py
 TS=

--- a/SDG01_query_topic_WoS.md
+++ b/SDG01_query_topic_WoS.md
@@ -224,9 +224,11 @@ TS=
     OR "unaffordab*" OR "exclusion" OR "land grab*" OR "appropriation of land" OR "insecurity"
     )      
     NEAR/5
-        ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labour market$"
-        OR "income" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
-        OR "land" OR "lands" OR "farmland$" OR "property" OR "natural resource$" OR "tenure"
+        ("economic resource$" OR "employment" OR "decent work" OR "paid work" OR "labo$r market" OR "labo$r force"
+        OR "income" OR "earnings" OR "wage" OR "wages" OR "livelihood$" OR "wealth" OR "inheritance" OR "inherit" OR ("of" NEAR/1 "assets")
+        OR "land" OR "lands" OR "landowner*" OR "farmland$" OR "livestock owner*" OR "livestock asset$"
+        OR "property" OR "home owner*" OR "homeowner*" OR "tenure" 
+        OR "natural resource$"
         )
   )
   AND


### PR DESCRIPTION
# Revisions to SDG01

## 1.4
- Updated the vulnerable people terms to include `men` in combination with `vulnerable OR marginalised OR...`, and terms for non-binary
- Updated the structure of the action phrases to make sure they do not find extra items than found by topic. This was done by expanding the action phrases (increasing the NEAR distance, and combining the topic terms as one unit before combining with action terms). This is the same pattern as used in 5.a. 
- Edited the action terms to be broader and more standardised, as done in 5.a #205 
- Phrase 2 - added a note that the string does find some potentially noisy results due to the term `income` - this finds many results mentioning e.g. "low-income countries" and disparities between populations, but not actually focusing on "access to income", which is the intention. However, removing this term loses many relevant results. We have not taken any further steps as the topics found are usually related to the scope (e.g. access to healthcare in low-income countries), and healthcare is a basic service, also covered by the topic.

Term additions, also implemented in 5.a:
- Phrase 1: Added `"entrepreneurial finance", "loan$"`
- Phrase 2: Changed "control" (#173) to `"control over" OR "control of" OR "control and use" OR "access and control" OR "individual control" OR "collective control" OR "territorial control" OR "land control"`, which removed a lot of noisy works about for example "diabetes control", "control groups" OR "control for".
- Phrase 2: Added `"land tenure"` in addition to "secure tenure", `land appropriation` in the section about "land grabbing" etc. in both approaches, and `reform*`´ as an action in action approach, as many works talk about "reform of land tenure" and this was previously not found, despite implying improvements
- Phrase 2: Added extra terms that are relevant: `inherit` as a variant of "inheritance", `of NEAR/1 assets` to find assets but exclude business ("return on assets"), `livestock asset$` and `livestock owner*`, `home owner*` and variants thereof, `wages` and `earnings`. 
- Phrase 2: Fixed `"labour market$"` to `"labo$r market"` and added `"labo$r force"`